### PR TITLE
feat: don't run tests on push to main

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -1,5 +1,8 @@
 name: CI tests
-on: [push]
+on:
+  push:
+    ignore-branch:
+      - 'main'
 jobs:
   test-runner:
     runs-on: ubuntu-latest # configure runner environment


### PR DESCRIPTION
This prevents the test-runner workflow from running on pushes to main. Tests are run on the branch of the PR already and pushing to main is restricted.